### PR TITLE
Make display name accessible. Fixes Issue #39

### DIFF
--- a/Content/OpenItemDialogBrowseFilter/ItemFilter.cs
+++ b/Content/OpenItemDialogBrowseFilter/ItemFilter.cs
@@ -42,7 +42,6 @@ namespace OpenItemDialogBrowseFilter
     public string ElementName => _elementName;
     public string ID => _id;
     public string Content => _content;
-
     public string Caption => _caption;
     /// <summary>
     /// Creates a browse project filter or esri_item item

--- a/Content/OpenItemDialogBrowseFilter/ItemFilter.cs
+++ b/Content/OpenItemDialogBrowseFilter/ItemFilter.cs
@@ -42,6 +42,8 @@ namespace OpenItemDialogBrowseFilter
     public string ElementName => _elementName;
     public string ID => _id;
     public string Content => _content;
+
+    public string Caption => _caption;
     /// <summary>
     /// Creates a browse project filter or esri_item item
     /// </summary>

--- a/Content/OpenItemDialogBrowseFilter/ProWindowMakeProFiltersViewModel.cs
+++ b/Content/OpenItemDialogBrowseFilter/ProWindowMakeProFiltersViewModel.cs
@@ -186,7 +186,7 @@ namespace OpenItemDialogBrowseFilter
             {
               var row = _displayItemsDataTable.NewRow();
               row["id"] = filter.ID;
-              row["name"] = filter.ElementName;
+              row["name"] = filter.Caption;
               _displayItemsDataTable.Rows.Add(row);
             }
             break;


### PR DESCRIPTION
Fixes Issue #39.
Issue was that the Browse Filter Spy+ did not display Filter's name. Problem can be solved by using `ItemFilter`'s `Caption` property.