### PR TITLE
Switch to local reference for Xaml Behaviors DLL

### DIFF
--- a/Configuration/ProStartPageConfig/ProStartPageConfig.csproj
+++ b/Configuration/ProStartPageConfig/ProStartPageConfig.csproj
@@ -26,9 +26,6 @@
     <Folder Include="Pages\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
-  </ItemGroup>
-  <ItemGroup>
     <Reference Include="ArcGIS.Desktop.Framework">
       <HintPath>C:\Program Files\ArcGIS\Pro\bin\ArcGIS.Desktop.Framework.dll</HintPath>
       <CopyLocal>False</CopyLocal>
@@ -97,6 +94,10 @@
     <Reference Include="ESRI.ArcGIS.ItemIndex">
       <HintPath>C:\Program Files\ArcGIS\Pro\bin\ESRI.ArcGIS.ItemIndex.dll</HintPath>
       <CopyLocal>False</CopyLocal>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Xaml.Behaviors">
+      <HintPath>C:\Program Files\ArcGIS\Pro\bin\Microsoft.Xaml.Behaviors.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
Removed NuGet package reference to Microsoft.Xaml.Behaviors.Wpf and added a direct assembly reference to Microsoft.Xaml.Behaviors.dll from the ArcGIS Pro installation directory to improve compatibility with the ArcGIS Pro environment.